### PR TITLE
Upgrade to .NET 9.0 and update package references and added a new example

### DIFF
--- a/PostgreSqlRequestReply/Consumer.Messages/Consumer.Messages.csproj
+++ b/PostgreSqlRequestReply/Consumer.Messages/Consumer.Messages.csproj
@@ -1,0 +1,7 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard20</TargetFramework>
+	</PropertyGroup>
+
+</Project>

--- a/PostgreSqlRequestReply/Consumer.Messages/Job.cs
+++ b/PostgreSqlRequestReply/Consumer.Messages/Job.cs
@@ -1,0 +1,12 @@
+﻿namespace Consumer.Messages
+{
+    public class Job
+    {
+        public char KeyChar { get; private set; }
+
+        public Job(char keyChar)
+        {
+            KeyChar = keyChar;
+        }
+    }
+}

--- a/PostgreSqlRequestReply/Consumer.Messages/Reply.cs
+++ b/PostgreSqlRequestReply/Consumer.Messages/Reply.cs
@@ -1,0 +1,14 @@
+﻿namespace Consumer.Messages
+{
+    public class Reply
+    {
+        public char KeyChar { get; private set; }
+        public int OsProcessId { get; private set; }
+
+        public Reply(char keyChar, int osProcessId)
+        {
+            KeyChar = keyChar;
+            OsProcessId = osProcessId;
+        }
+    }
+}

--- a/PostgreSqlRequestReply/Consumer/Consumer.csproj
+++ b/PostgreSqlRequestReply/Consumer/Consumer.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net9.0</TargetFramework>
+	</PropertyGroup>
+	
+	<ItemGroup>
+		<PackageReference Include="Npgsql" Version="9.0.3" />
+		<PackageReference Include="Rebus" Version="8.8.0" />
+		<PackageReference Include="Rebus.PostgreSql" Version="9.1.1" />
+	</ItemGroup>
+	
+	<ItemGroup>
+		<ProjectReference Include="..\Consumer.Messages\Consumer.Messages.csproj" />
+	</ItemGroup>
+	
+</Project>

--- a/PostgreSqlRequestReply/Consumer/Program.cs
+++ b/PostgreSqlRequestReply/Consumer/Program.cs
@@ -1,0 +1,36 @@
+﻿using Consumer.Messages;
+using Rebus.Activation;
+using Rebus.Config;
+using Rebus.Logging;
+using System;
+using System.Diagnostics;
+
+namespace Consumer;
+
+internal class Program
+{
+    private const string ConnectionString = "server=localhost; database=rebus2_test; user id=postgres; password=postgres; maximum pool size=30";
+    private const string TableName = "producer.input";
+
+    private static void Main()
+    {
+        using var adapter = new BuiltinHandlerActivator();
+
+        adapter.Handle<Job>(async (bus, job) =>
+        {
+            var keyChar = job.KeyChar;
+            var processId = Process.GetCurrentProcess().Id;
+            var reply = new Reply(keyChar, processId);
+
+            await bus.Reply(reply);
+        });
+
+        Configure.With(adapter)
+            .Logging(l => l.ColoredConsole(minLevel: LogLevel.Warn))
+            .Transport(t => t.UsePostgreSql(ConnectionString, TableName, "consumer.input"))
+            .Start();
+
+        Console.WriteLine("Press ENTER to quit");
+        Console.ReadLine();
+    }
+}

--- a/PostgreSqlRequestReply/Directory.Build.props
+++ b/PostgreSqlRequestReply/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+
+	<PropertyGroup>
+		<ArtifactsPath>$(MSBuildThisFileDirectory)artifacts</ArtifactsPath>
+	</PropertyGroup>
+
+</Project>

--- a/PostgreSqlRequestReply/PostgreSqlRequestReply.sln
+++ b/PostgreSqlRequestReply/PostgreSqlRequestReply.sln
@@ -1,0 +1,40 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36310.24 d17.14
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{AD83B77A-4D26-424E-97E1-C069143B4DC4}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+		README.md = README.md
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Producer", "Producer\Producer.csproj", "{F3223EB8-F9BA-43DE-B931-F06F3453424C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Consumer", "Consumer\Consumer.csproj", "{75E61A8E-3C76-4717-9FC5-9D24E072B18E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Consumer.Messages", "Consumer.Messages\Consumer.Messages.csproj", "{56A97AEA-AF41-41D0-895C-D76E0008499F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F3223EB8-F9BA-43DE-B931-F06F3453424C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F3223EB8-F9BA-43DE-B931-F06F3453424C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F3223EB8-F9BA-43DE-B931-F06F3453424C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F3223EB8-F9BA-43DE-B931-F06F3453424C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{75E61A8E-3C76-4717-9FC5-9D24E072B18E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{75E61A8E-3C76-4717-9FC5-9D24E072B18E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{75E61A8E-3C76-4717-9FC5-9D24E072B18E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{75E61A8E-3C76-4717-9FC5-9D24E072B18E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{56A97AEA-AF41-41D0-895C-D76E0008499F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{56A97AEA-AF41-41D0-895C-D76E0008499F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{56A97AEA-AF41-41D0-895C-D76E0008499F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{56A97AEA-AF41-41D0-895C-D76E0008499F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/PostgreSqlRequestReply/Producer/Producer.csproj
+++ b/PostgreSqlRequestReply/Producer/Producer.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net9.0</TargetFramework>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Npgsql" Version="9.0.3" />
+		<PackageReference Include="Rebus" Version="8.8.0" />
+		<PackageReference Include="Rebus.PostgreSql" Version="9.1.1" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Consumer.Messages\Consumer.Messages.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/PostgreSqlRequestReply/Producer/Program.cs
+++ b/PostgreSqlRequestReply/Producer/Program.cs
@@ -1,0 +1,50 @@
+﻿using Consumer.Messages;
+using Rebus.Activation;
+using Rebus.Config;
+using Rebus.Logging;
+using Rebus.Routing.TypeBased;
+using System;
+
+namespace Producer;
+
+internal class Program
+{
+    private const string ConnectionString = "server=localhost; database=rebus2_test; user id=postgres; password=postgres; maximum pool size=30";
+    private const string TableName = "producer.input";
+
+    private static void Main()
+    {
+        using var adapter = new BuiltinHandlerActivator();
+
+        adapter.Handle<Reply>(async reply =>
+        {
+            await Console.Out.WriteLineAsync($"Got reply '{reply.KeyChar}' (from OS process {reply.OsProcessId})");
+        });
+
+        Configure.With(adapter)
+            .Logging(l => l.ColoredConsole(minLevel: LogLevel.Warn))
+            .Transport(t => t.UsePostgreSql(ConnectionString, TableName, "producer.input"))
+            .Routing(r => r.TypeBased().MapAssemblyOf<Job>("consumer.input"))
+            .Start();
+
+        Console.WriteLine("Press Q to quit or any other key to produce a job");
+
+        while (true)
+        {
+            var keyChar = char.ToLower(Console.ReadKey(true).KeyChar);
+
+            switch (keyChar)
+            {
+                case 'q':
+                    goto quit;
+
+                default:
+                    adapter.Bus.Send(new Job(keyChar)).Wait();
+                    break;
+            }
+        }
+
+    quit:
+        Console.WriteLine("Quitting...");
+    }
+}

--- a/PostgreSqlRequestReply/README.md
+++ b/PostgreSqlRequestReply/README.md
@@ -1,0 +1,5 @@
+## PostgreSql RequestReply
+
+This sample demonstrates how a producer can produce jobs and receive replies from consumer when done.
+
+The sample uses PostgreSql as the transport (at least by default), and it requires a local database called "rebus2_test".

--- a/PostgreSqlScaleout/Consumer/Consumer.csproj
+++ b/PostgreSqlScaleout/Consumer/Consumer.csproj
@@ -1,14 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="Npgsql" Version="8.0.3" />
-		<PackageReference Include="Rebus" Version="8.4.2" />
-		<PackageReference Include="Rebus.PostgreSql" Version="9.0.1" />
-		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+		<PackageReference Include="Npgsql" Version="9.0.3" />
+		<PackageReference Include="Rebus" Version="8.8.0" />
+		<PackageReference Include="Rebus.PostgreSql" Version="9.1.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Messages\Messages.csproj" />

--- a/PostgreSqlScaleout/Consumer/Program.cs
+++ b/PostgreSqlScaleout/Consumer/Program.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.Threading.Tasks;
-using Messages;
+﻿using Messages;
 using Rebus.Activation;
 using Rebus.Config;
 using Rebus.Logging;
-using Rebus.PostgreSql.Transport;
+using System;
+using System.Threading.Tasks;
 
 namespace Consumer
 {
@@ -16,7 +15,7 @@ namespace Consumer
             {
                 adapter.Handle<Job>(async job =>
                 {
-                    Console.WriteLine("Processing job {0}", job.JobNumber);
+                    Console.WriteLine("Processing job {0} - {1}", job.JobNumber, job.JobUuid);
 
                     await Task.Delay(TimeSpan.FromMilliseconds(300));
                 });

--- a/PostgreSqlScaleout/Directory.Build.props
+++ b/PostgreSqlScaleout/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+
+	<PropertyGroup>
+		<ArtifactsPath>$(MSBuildThisFileDirectory)artifacts</ArtifactsPath>
+	</PropertyGroup>
+
+</Project>

--- a/PostgreSqlScaleout/Messages/Job.cs
+++ b/PostgreSqlScaleout/Messages/Job.cs
@@ -11,6 +11,7 @@ namespace Messages
         }
 
         public int JobNumber { get; }
+
         public Guid JobUuid { get; }
     }
 }

--- a/PostgreSqlScaleout/Messages/Messages.csproj
+++ b/PostgreSqlScaleout/Messages/Messages.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
 	<PropertyGroup>
-		<OutputType>Library</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>netstandard2.0</TargetFramework>
 	</PropertyGroup>
+
 </Project>

--- a/PostgreSqlScaleout/PostgreSqlScaleout.sln
+++ b/PostgreSqlScaleout/PostgreSqlScaleout.sln
@@ -5,6 +5,7 @@ VisualStudioVersion = 17.9.34728.123
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{38B04808-A0C5-46B5-9632-E9D6938AA9EB}"
 	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/PostgreSqlScaleout/Producer/Producer.csproj
+++ b/PostgreSqlScaleout/Producer/Producer.csproj
@@ -1,13 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Npgsql" Version="8.0.3" />
-		<PackageReference Include="Rebus" Version="8.4.2" />
-		<PackageReference Include="Rebus.PostgreSql" Version="9.0.1" />
-		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+		<PackageReference Include="Npgsql" Version="9.0.3" />
+		<PackageReference Include="Rebus" Version="8.8.0" />
+		<PackageReference Include="Rebus.PostgreSql" Version="9.1.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Messages\Messages.csproj" />

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Check out
 * [MessageBus](/MessageBus) - demonstrates how tree totally independent endpoints can do pub/sub with a central database being their only connection
 * [RequestReply](/RequestReply) - demonstrates how a client can send a request to a server, which then can reply back to the client
 * [SharedNothing](/SharedNothing) - demonstrates how a publisher and a subscriber can communicate without sharing class libraries or anything
+* [PostgreSqlRequestReply](/PostgreSqlRequestReply) - demonstrates how a client can send a request to a server, which then can reply back to the client
 
 ### Scaleout samples
 


### PR DESCRIPTION
- Updated target framework for `Consumer.csproj` and `Producer.csproj` from `net8.0` to `net9.0`.
- Updated package references:
  - `Npgsql` to version `9.0.3`
  - `Rebus` to version `8.8.0`
  - `Rebus.PostgreSql` to version `9.1.1`
- Modified `Console.WriteLine` in `Program.cs` to include `job.JobUuid`.
- Added `JobUuid` property to the `Job` class in `Job.cs`.
- Changed `Messages.csproj` to target `netstandard2.0`.
- Restructured `PostgreSqlScaleout.sln` for improved organization.
- Added `Directory.Build.props` to standardize build artifact output.

- Added a producer-consumer example with response using PostgreSQL as transport.
This commit introduces a new project structure for a sample application demonstrating a producer-consumer pattern using PostgreSQL. Key additions include a `Directory.Build.props` file, a solution file (`PostgreSqlRequestReply.sln`), and project files for `Consumer`, `Producer`, and `Consumer.Messages`. New classes `Job` and `Reply` are created for message representation, and the `Program.cs` files are updated to handle message sending and receiving with the Rebus library. A README file is also added to outline the application and its requirements.